### PR TITLE
在Component内部使用，无法获取Component的元素内容

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ class Wxml2Canvas {
         }   
         
         this.element = options.element;
-        this.object = options.obj;
+        this.obj = options.obj;
         this.width = options.width * this.zoom || 0;
         this.height = options.height * this.zoom || 0;
         this.destZoom = options.destZoom || 3;
@@ -67,7 +67,7 @@ class Wxml2Canvas {
         this.distance = 0;
         this.progress(0);
 
-        this.ctx = wx.createCanvasContext(this.element, this.object);
+        this.ctx = wx.createCanvasContext(this.element, this.obj);
         this.ctx.font = this.font;
         this.ctx.setTextBaseline('top');
         this.ctx.setStrokeStyle('white');
@@ -1044,8 +1044,8 @@ class Wxml2Canvas {
     _getWxml (item, style) {
         let self = this;
         let query;
-        if(this.object) {
-            query = wx.createSelectorQuery().in(this.object);
+        if(this.obj) {
+            query = wx.createSelectorQuery().in(this.obj);
         }else {
             query = wx.createSelectorQuery();
         }

--- a/src/index.js
+++ b/src/index.js
@@ -183,7 +183,7 @@ class Wxml2Canvas {
                 obj.destHeight = self.destHeight;
             }
 
-            wx.canvasToTempFilePath(obj, self.object);
+            wx.canvasToTempFilePath(obj, self.obj);
         }, self.device.system.indexOf('iOS') === -1 ? 300 : 100);
     }
 


### PR DESCRIPTION
fix(变量名称错误): 修复变量名称错误，导致无法获取Component内部元素，从而无法在Component内部绘制canvas的问题

原因：变量名称错误导致wx.createSelectorQuery().in(this.object);无法被执行到，从而无法获取Component内部元素。